### PR TITLE
Change schema name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Ce fichier répertorie les changements entre différentes versions d'un schéma.
 
+## version 1.0.2
+Changement du nom du schéma en "Itinéraires de randonnées"
+
 ## version 1.0.1
 Suppression du schéma externe `https://geojson.org/schema/Point.json`, plus utilisé depuis l'aplatissement de l'objet parking
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Afin d'apporter une valeur ajoutée à ce projet, le Parc national souhaite trav
 
 ## Schéma
 
-Schéma au format [JSON Schema](https://json-schema.org/), version [`draft-07`](https://json-schema.org/specification-links.html#draft-7) disponible [ici](https://github.com/PnX-SI/schema_randonnee/raw/v1.0.1/schema.json).
+Schéma au format [JSON Schema](https://json-schema.org/), version [`draft-07`](https://json-schema.org/specification-links.html#draft-7) disponible [ici](https://github.com/PnX-SI/schema_randonnee/raw/v1.0.2/schema.json).
 
-Un fichier d'exemple valide avec 10 randonnées est disponible [ici](https://github.com/PnX-SI/schema_randonnee/raw/v1.0.1/exemple-valide.json). L'intégralité des champs du premier itinéraire sont renseignés en guise d'exemple exhaustif.
+Un fichier d'exemple valide avec 10 randonnées est disponible [ici](https://github.com/PnX-SI/schema_randonnee/raw/v1.0.2/exemple-valide.json). L'intégralité des champs du premier itinéraire sont renseignés en guise d'exemple exhaustif.
 
 ## Validateur
 

--- a/schema.json
+++ b/schema.json
@@ -1,7 +1,7 @@
 {
-  "$id": "https://github.com/PnX-SI/schema_randonnee/raw/v1.0.1/schema.json",
+  "$id": "https://github.com/PnX-SI/schema_randonnee/raw/v1.0.2/schema.json",
   "$schema": "http://json-schema.org/draft-07/schema",
-  "title": "Schéma des itinéraires de randonnée",
+  "title": "Itinéraires de randonnée",
   "description": "Spécification du fichier d'échange relatif aux itinéraires de randonnée",
   "type": "object",
   "keywords": [
@@ -23,7 +23,7 @@
     {
       "title": "Fichier valide (JSON)",
       "name": "exemple-valide.json",
-      "path": "https://github.com/PnX-SI/schema_randonnee/raw/v1.0.1/exemple-valide.json"
+      "path": "https://github.com/PnX-SI/schema_randonnee/raw/v1.0.2/exemple-valide.json"
     }
   ],
   "sources": [
@@ -33,8 +33,8 @@
     }
   ],
   "created": "2021-04-08",
-  "lastModified": "2021-08-29",
-  "version": "1.0.1",
+  "lastModified": "2021-10-11",
+  "version": "1.0.2",
   "definitions": {
     "GeoJSON_LineString": {
       "$id": "linestring",

--- a/schemas.yml
+++ b/schemas.yml
@@ -1,4 +1,4 @@
-title: "Schéma des itinéraires de randonnée"
+title: "Iinéraires de randonnée"
 description : "Spécification du fichier d'échange relatif aux itinéraires de randonnée"
 homepage: "https://github.com/PnX-SI/schema-randonnee"
 schemas:


### PR DESCRIPTION
Pour plus de facilité de lecture sur le site schema.data.gouv.fr, nous préférons retirer le mot "Schéma" dans le nom du schéma. Cela facilite la recherche sur le site schema.data.gouv.fr.
Après l'acceptation de cette PR, il faudra faire une nouvelle release en v1.0.2